### PR TITLE
Move modular rcs to general 'rcs' category

### DIFF
--- a/GameData/VABOrganizer-RP-1 Configs/Patches/04control.cfg
+++ b/GameData/VABOrganizer-RP-1 Configs/Patches/04control.cfg
@@ -1,7 +1,7 @@
 // Added SubCategories for Control
 
 // RCS
-@PART:HAS[@MODULE[ModuleRCSFX],#category[Control]]:LAST[RP-1]
+@PART[*|ROE-ModularRCS]:HAS[@MODULE[ModuleRCSFX],#category[Control]]:LAST[RP-1]
 	{
 	%VABORGANIZER
 		{
@@ -49,7 +49,7 @@ ORGANIZERSUBCATEGORY
 	Priority = 9
 	CategoryPriority = 15
 	}
-@PART[*_138|RO_FASA_MercuryPodRCS|ROE-ModularRCS]:HAS[@MODULE[ModuleRCSFX],#category[Control]]:LAST[RP-1]
+@PART[*_138|RO_FASA_MercuryPodRCS]:HAS[@MODULE[ModuleRCSFX],#category[Control]]:LAST[RP-1]
 	{
 	%VABORGANIZER
 		{


### PR DESCRIPTION
This RCS can be scaled, so it is more useful in the general category

<img width="654" height="1038" alt="image" src="https://github.com/user-attachments/assets/4762707c-ac1d-4531-97c1-f56af2ad1327" />